### PR TITLE
chore(pre-align): align heading structure (2 docs) with ko

### DIFF
--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,4 +1,7 @@
-## Network > Network Interface > Console User Guide
+<!-- pre-align:aligned sig=d38698310a3d -->
+
+<a id="network-network-interface-console-user-guide"></a>
+## Network > Network Interface > Console User Guide { #network-network-interface-console-user-guide }
 
 
 <a id="create"></a>

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,4 +1,7 @@
-## Network > Network Interface > Overview
+<!-- pre-align:aligned sig=4419142f4638 -->
+
+<a id="network-network-interface-overview"></a>
+## Network > Network Interface > Overview { #network-network-interface-overview }
 
 NHN Cloud provides network interface features.
 

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,4 +1,7 @@
-## Network > Network Interface > コンソール使用ガイド
+<!-- pre-align:aligned sig=d38698310a3d -->
+
+<a id="network-network-interface-console-user-guide"></a>
+## Network > Network Interface > コンソール使用ガイド { #network-network-interface-console-user-guide }
 
 
 <a id="create"></a>

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,4 +1,7 @@
-## Network > Network Interface > 概要
+<!-- pre-align:aligned sig=4419142f4638 -->
+
+<a id="network-network-interface-overview"></a>
+## Network > Network Interface > 概要 { #network-network-interface-overview }
 
 NHN Cloudはネットワークインターフェイス機能を提供します。
 

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,4 +1,7 @@
-## Network > Network Interface > 콘솔 사용 가이드
+<!-- pre-align:aligned sig=d38698310a3d -->
+
+<a id="network-network-interface-console-user-guide"></a>
+## Network > Network Interface > 콘솔 사용 가이드 { #network-network-interface-console-user-guide }
 
 
 <a id="create"></a>

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,4 +1,7 @@
-## Network > Network Interface > 개요
+<!-- pre-align:aligned sig=4419142f4638 -->
+
+<a id="network-network-interface-overview"></a>
+## Network > Network Interface > 개요 { #network-network-interface-overview }
 
 NHN Cloud는 네트워크 인터페이스 기능을 제공합니다.
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `beta` |
| Scope | 2 doc(s) scanned · 6 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/118/ |
| Generated | 2026-07-11T14:48:17 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`beta`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-Interface%2Ftree%2Fbeta&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-Interface%2Fpull%2F17&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-Interface%2Fpull%2F17&ref=beta&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Network-Interface`